### PR TITLE
Repository Count Function

### DIFF
--- a/webapi/Controllers/PostController.cs
+++ b/webapi/Controllers/PostController.cs
@@ -40,6 +40,7 @@ public class PostController(IBaseService<Post> postService, IBaseService<Categor
         {
             if (posts[i].Id == postDTOs[i].Id)
             {
+                postDTOs[i].CommentCount = await _postService.Count(p => p.Id == postDTOs[i].Id, p => p.Comments.Count());
                 postDTOs[i].LikedByCurrentUser = await _likeService.IsLiked(posts[i].LikedByUserID, User.Claims.First(c => c.Type.Equals("user_id"))?.Value);
             }
         }
@@ -62,9 +63,7 @@ public class PostController(IBaseService<Post> postService, IBaseService<Categor
 
         ServerPostDTO postData = new(post);
 
-        // postData.CommentCount = await _postService.Count(id, p => p.Where(b => b.Id == id).SelectMany(d => d.Comments).CountAsync());
-
-
+        postData.CommentCount = await _postService.Count(p => p.Id == postData.Id, p => p.Comments.Count());
         postData.LikedByCurrentUser = await _likeService.IsLiked(post.LikedByUserID, User.Claims.First(c => c.Type.Equals("user_id"))?.Value);
 
         return Ok(postData);
@@ -94,6 +93,7 @@ public class PostController(IBaseService<Post> postService, IBaseService<Categor
         {
             if (posts[i].Id == postDTOs[i].Id)
             {
+                postDTOs[i].CommentCount = await _postService.Count(p => p.Id == postDTOs[i].Id, p => p.Comments.Count());
                 postDTOs[i].LikedByCurrentUser = await _likeService.IsLiked(posts[i].LikedByUserID, User.Claims.First(c => c.Type.Equals("user_id"))?.Value);
             }
         }
@@ -134,6 +134,7 @@ public class PostController(IBaseService<Post> postService, IBaseService<Categor
         {
             if (posts[i].Id == postDTOs[i].Id)
             {
+                postDTOs[i].CommentCount = await _postService.Count(p => p.Id == postDTOs[i].Id, p => p.Comments.Count());
                 postDTOs[i].LikedByCurrentUser = await _likeService.IsLiked(posts[i].LikedByUserID, User.Claims.First(c => c.Type.Equals("user_id"))?.Value);
             }
         }

--- a/webapi/Repositories/GenericRepository.cs
+++ b/webapi/Repositories/GenericRepository.cs
@@ -16,6 +16,7 @@ public interface IGenericRepository<T> where T : BaseEntity
     Task Add(T entity);
     Task Update(T entity);
     Task Delete(T entity);
+    Task<int> Count(Expression<Func<T, bool>> parentFilter, Expression<Func<T, int>> childSelector);
 }
 
 public class GenericRepository<T> : IGenericRepository<T> where T : BaseEntity
@@ -85,5 +86,14 @@ public class GenericRepository<T> : IGenericRepository<T> where T : BaseEntity
         }
         _dbSet.Remove(entity);
         await _context.SaveChangesAsync().ConfigureAwait(false);
+    }
+
+    public async Task<int> Count(Expression<Func<T, bool>> parentFilter, Expression<Func<T, int>> childSelector)
+    {
+        return await _dbSet
+            .Where(parentFilter)
+            .Select(childSelector)
+            .SumAsync()
+            .ConfigureAwait(false);
     }
 }

--- a/webapi/Services/BaseService.cs
+++ b/webapi/Services/BaseService.cs
@@ -12,6 +12,7 @@ public interface IBaseService<T> where T : BaseEntity
     Task Create(T entity);
     Task Update(T entity);
     Task Delete(string id);
+    Task<int> Count(Expression<Func<T, bool>> parentFilter, Expression<Func<T, int>> childSelector);
 }
 
 public class BaseService<T>(IGenericRepository<T> repository) : IBaseService<T> where T : BaseEntity
@@ -46,5 +47,10 @@ public class BaseService<T>(IGenericRepository<T> repository) : IBaseService<T> 
         {
             await _repository.Delete(entity).ConfigureAwait(false);
         }
+    }
+
+    public async Task<int> Count(Expression<Func<T, bool>> parentFilter, Expression<Func<T, int>> childSelector)
+    {
+        return await _repository.Count(parentFilter, childSelector).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
Added so that when a post is fetched, it will do an extra fetch to look for how many comments are attached to it.

This includes a function in the generic repository that can be used to count. 
Currently only tested to count children of an object. 